### PR TITLE
Migrating from master-slave terminology

### DIFF
--- a/backend/apps/db/views.py
+++ b/backend/apps/db/views.py
@@ -396,9 +396,9 @@ class MySQLStatusViewSet(APIView):
             col,results = dbapi.get_metadata(7,connectinfo)
         elif ( str(request_type) == 'innodb'):
             col,results = dbapi.get_metadata(8,connectinfo)
-        elif ( str(request_type) == 'master'):
+        elif ( str(request_type) == 'main'):
             col,results = dbapi.get_metadata(9,connectinfo)
-        elif ( str(request_type) == 'slave'):
+        elif ( str(request_type) == 'subordinate'):
             col,results = dbapi.get_metadata(10,connectinfo)
         elif ( str(request_type) == 'kill'):
             sessionid = request.data['sessionid']

--- a/backend/utils/db_api.py
+++ b/backend/utils/db_api.py
@@ -96,13 +96,13 @@ class db_api():
         elif (flag == 8):
             sql = "show engine innodb status;"
             col, results = self.mysql_query(connectinfo,sql)
-        # show master status
+        # show main status
         elif (flag == 9):
-            sql = "show master status;"
+            sql = "show main status;"
             col, results = self.mysql_query(connectinfo,sql)
         # show salve status
         elif (flag == 10):
-            sql = "show slave status;"
+            sql = "show subordinate status;"
             col, results = self.mysql_query(connectinfo,sql)
         return (col,results)
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.